### PR TITLE
Update default value for content files argument

### DIFF
--- a/src/webmonchow/amq/broadcast.py
+++ b/src/webmonchow/amq/broadcast.py
@@ -127,7 +127,7 @@ def get_options(argv):
         "-m",
         help="List of content files to broadcast, separated by comma.",
         dest="content_files" "",
-        default=service_content_files(),
+        default=",".join(service_content_files()),
     )
     options = parser.parse_args(argv)
     return options

--- a/src/webmonchow/pv/broadcast.py
+++ b/src/webmonchow/pv/broadcast.py
@@ -134,9 +134,8 @@ def get_options(argv):
     parser.add_argument("--database-name", dest="database", default=os.getenv("DATABASE_NAME", "workflow"))
     parser.add_argument(
         "--pv-files",
-        "-f",
         dest="pv_files",
-        default=service_content_files(),
+        default=",".join(service_content_files()),
         help="List of content files to broadcast, separated by commas",
     )
     options = parser.parse_args(argv)

--- a/tests/unit/test_amq_broadcast.py
+++ b/tests/unit/test_amq_broadcast.py
@@ -67,7 +67,7 @@ def test_get_options_default():
     assert options.user == "icat"
     assert options.password == "icat"
     assert options.broker == "localhost:61613"
-    file_names = [os.path.basename(filename) for filename in options.content_files]
+    file_names = [os.path.basename(filename) for filename in options.content_files.split(",")]
     assert sorted(file_names) == ["dasmon.json", "pvsd.json", "translation.json"]
 
 

--- a/tests/unit/test_pv_broadcast.py
+++ b/tests/unit/test_pv_broadcast.py
@@ -89,7 +89,7 @@ def test_get_options_default():
     assert options.host == "localhost"
     assert options.port == "5432"
     assert options.database == "workflow"
-    assert options.pv_files[0].endswith("services/dasmon.json")
+    assert os.path.basename(options.pv_files) == "dasmon.json"
 
 
 def test_get_options():


### PR DESCRIPTION
This commit changes the default value for the `content_files` and `pv_files` arguments to a comma-separated string. This update ensures compatibility and consistency in the handling of default content file lists across different modules.

# Description of the changes


Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
