### PR TITLE
Increase message broadcast intervals.

### DIFF
--- a/src/webmonchow/amq/broadcast.py
+++ b/src/webmonchow/amq/broadcast.py
@@ -57,7 +57,7 @@ def message_generator(data):
     tuple
         A tuple containing the destination queue or topic, and message to send.
     """
-    time_step = 0.5  # in seconds. Maximum frequency for any message to be sent
+    time_step = 1.0  # in seconds. Maximum frequency for any message to be sent
     count = 0
     while True:
         for queue_or_topic, programmes in data.items():

--- a/src/webmonchow/amq/services/dasmon.json
+++ b/src/webmonchow/amq/services/dasmon.json
@@ -1,16 +1,16 @@
 {
   "/topic/SNS.HYSA.STATUS.DASMON": [
-    {"frequency": 2,
+    {"frequency": 10,
       "message": {"src_name": "dasmon",
         "status": "0"}}
   ],
   "/topic/SNS.ARCS.STATUS.DASMON": [
-    {"frequency": 2,
+    {"frequency": 10,
       "message": {"src_name": "dasmon",
         "status": "0"}}
   ],
   "/topic/SNS.REF_M.STATUS.DASMON": [
-    {"frequency": 2,
+    {"frequency": 10,
       "message": {"src_name": "dasmon",
         "status": "0"}}
   ],

--- a/src/webmonchow/amq/services/pvsd.json
+++ b/src/webmonchow/amq/services/pvsd.json
@@ -1,16 +1,16 @@
 {
   "/topic/SNS.HYSA.STATUS.PVSD": [
-    {"frequency": 1,
+    {"frequency": 10,
       "message": {"src_name": "pvstreamer",
         "status": "0"}}
   ],
   "/topic/SNS.ARCS.STATUS.PVSD": [
-    {"frequency": 1,
+    {"frequency": 10,
       "message": {"src_name": "pvsd",
         "status": "0"}}
   ],
   "/topic/SNS.REF_M.STATUS.PVSD": [
-    {"frequency": 1,
+    {"frequency": 10,
       "message": {"src_name": "pvsd",
         "status": "0"}}
   ]

--- a/src/webmonchow/pv/broadcast.py
+++ b/src/webmonchow/pv/broadcast.py
@@ -59,7 +59,7 @@ def pv_generator(data):
     tuple
         A tuple containing the SQL function name, instrument, name, and evaluated function value of the PV.
     """
-    time_step = 0.5  # in seconds. Maximum frequency for any message to be sent
+    time_step = 1.0  # in seconds. Maximum frequency for any message to be sent
     count = 0
     while True:
         for sql_function, pvs in data.items():

--- a/src/webmonchow/pv/services/dasmon.json
+++ b/src/webmonchow/pv/services/dasmon.json
@@ -1,41 +1,41 @@
 {
   "pvUpdate": [
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "HYSA",
       "name": "sinPV",
       "function": "100*math.sin({x}/3600)"
     },
-    {"frequency": 2,
+    {"frequency": 20,
       "instrument": "HYSA",
       "name": "sawtoothPV",
       "function": "{x}%600"
     },
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "ARCS",
       "name": "BL18:SE:SampleTemp",
       "function": "300+10*math.sin({x}/300)+random.random()*2"
     },
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "ARCS",
       "name": "chopper3_TDC",
       "function": "random.choice([2.09e6, 7.65e6, 1.32e7])"
     },
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "ARCS",
       "name": "LKS1A",
       "function": "490+10*math.sin({x}/300)+random.random()"
     },
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "ARCS",
       "name": "LKS1B",
       "function": "325+math.sin({x}/300)+random.random()"
     },
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "ARCS",
       "name": "LKS1C",
       "function": "282+math.sin({x}/300)+random.random()"
     },
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "REF_M",
       "name": "MagneticField",
       "function": "100*math.sin({x}/300)+random.random()"
@@ -50,14 +50,14 @@
       "name": "SF2",
       "function": "random.choice([0, 1])"
     },
-    {"frequency": 6,
+    {"frequency": 10,
       "instrument": "REF_M",
       "name": "SampleTemperature",
       "function": "273+100*({x}/60-math.floor(0.5+{x}/60))"
     }
   ],
   "pvStringUpdate": [
-    {"frequency": 1,
+    {"frequency": 10,
       "instrument": "HYSA",
       "name": "xString",
       "function": "'x = {x} seconds'"

--- a/tests/integration/test_amq_broadcast.py
+++ b/tests/integration/test_amq_broadcast.py
@@ -13,7 +13,7 @@ def test_broadcast(content_files):
     programmes = read_contents([filepath for filepath in content_files["amq"].values()])
     with patch("stomp.Connection", autospec=True) as mock_connection:
         mock_conn = mock_connection.return_value
-        max_items = 100  # Limit the generator to a maximum number of items
+        max_items = 40  # Limit the generator to a maximum number of items
         limited_message_gen = itertools.islice(message_generator(programmes), max_items)
         broadcast(mock_conn, limited_message_gen)
         assert mock_conn.send.call_count == max_items

--- a/tests/integration/test_pv_broadcast.py
+++ b/tests/integration/test_pv_broadcast.py
@@ -12,7 +12,7 @@ from webmonchow.pv.broadcast import broadcast, pv_generator, read_contents
 def test_broadcast(content_files):
     programmes = read_contents([filepath for filepath in content_files["pv"].values()])
     mock_conn = MagicMock()
-    max_items = 100  # Limit the generator to a maximum number of items
+    max_items = 40  # Limit the generator to a maximum number of items
     limited_message_gen = itertools.islice(pv_generator(programmes), max_items)
     broadcast(mock_conn, limited_message_gen)
     assert mock_conn.commit.call_count == max_items


### PR DESCRIPTION
Updated time_step and frequency values to reduce message broadcast frequencies across multiple services. This change aims to improve system performance by lowering the load associated with high-frequency broadcasts.

# Description of the changes


Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
