### PR TITLE
Remove PyPI publishing job from workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,6 @@ name: conda packaging and deployment
 on:
   workflow_dispatch:
   push:
-    branches: [qa, main]
     tags: ['v*']
 
 jobs:
@@ -45,31 +44,3 @@ jobs:
           if [ "${IS_RC}" = "true" ]; then CONDA_LABEL="rc"; fi
           echo pushing ${{ github.ref }} with label $CONDA_LABEL
           anaconda upload --label $CONDA_LABEL conda.recipe/noarch/mypackagename*.tar.bz2
-
-  pypi-publish:
-    name: upload release to PyPI
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          channels: conda-forge,defaults
-          mamba-version: "*"
-          environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
-      - name: build pypi package
-        run: |
-          # build the package
-          VERSION=$(versioningit .) python -m build
-      # publish your distributions here (need to setup on PyPI first)
-      - name: Publish package distributions to PyPI
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,7 +31,7 @@ jobs:
           echo "versioningit $(versioningit ../)"
           # build the package
           VERSION=$(versioningit ../) conda mambabuild --channel conda-forge --output-folder . .
-          conda verify noarch/mypackagename*.tar.bz2
+          conda verify noarch/webmonchow*.tar.bz2
       - name: upload conda package to anaconda
         shell: bash -l {0}
         if: startsWith(github.ref, 'refs/tags/v')
@@ -43,4 +43,4 @@ jobs:
           CONDA_LABEL="main"
           if [ "${IS_RC}" = "true" ]; then CONDA_LABEL="rc"; fi
           echo pushing ${{ github.ref }} with label $CONDA_LABEL
-          anaconda upload --label $CONDA_LABEL conda.recipe/noarch/mypackagename*.tar.bz2
+          anaconda upload --label $CONDA_LABEL conda.recipe/noarch/webmonchow*.tar.bz2


### PR DESCRIPTION
The PyPI publishing steps have been removed from the GitHub Actions workflow. This change focuses the workflow solely on handling Anaconda uploads, simplifying the CI/CD setup and reducing maintenance efforts. Future PyPI publishing will need to be handled separately or reconfigured.

# Description of the changes


Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
