### PR TITLE
Remove branches from GitHub Actions workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [next, qa, main]
+    branches: [next]
     tags: ['v*']
 
 jobs:


### PR DESCRIPTION
The GitHub Actions workflow is now triggered only for the 'next' branch, and no longer runs for 'qa' and 'main' branches. This change simplifies the workflow's trigger conditions, focusing testing efforts on 'next'.

# Description of the changes


Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
