### PR TITLE
Add instrument NOM for time limit test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           channels: conda-forge,defaults

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,7 @@ Notes for the next major or minor release of `webmonchow`.
 **Of interest to the User**:
 
 - PR #XYZ one-liner description
+- PR #15 Add NOM messages for translation, pvsd and dasmon
 
 **Of interest to the Developer:**
 

--- a/src/webmonchow/amq/services/dasmon.json
+++ b/src/webmonchow/amq/services/dasmon.json
@@ -19,6 +19,11 @@
       "message": {"src_name": "dasmon",
         "status": "0"}}
   ],
+  "/topic/SNS.NOM.STATUS.DASMON": [
+    {"frequency": 10,
+      "message": {"src_name": "dasmon",
+        "status": "0"}}
+  ],
   "/topic/SNS.HYSA.APP.DASMON": [
     {"frequency": 10,
       "message":
@@ -79,6 +84,25 @@
         "scanning": false,
         "system_dasmon": 0,
         "system_postprocessing": "Created REF_L reduction script",
+        "system_pvsd": 0,
+        "total_charge": 3.03988e+10,
+        "total_counts": 111735,
+        "total_time": 2993.14
+      }
+    }
+  ],
+  "/topic/SNS.NOM.APP.DASMON": [
+    {"frequency": 10,
+      "message":
+      {"monitors": {"1": 0, "2": 0, "8":  0},
+        "count_rate": 0,
+        "has_states_count": 0,
+        "paused": false,
+        "recording": false,
+        "scan_index": 0,
+        "scanning": false,
+        "system_dasmon": 0,
+        "system_postprocessing": "Created NOM reduction script",
         "system_pvsd": 0,
         "total_charge": 3.03988e+10,
         "total_counts": 111735,

--- a/src/webmonchow/amq/services/pvsd.json
+++ b/src/webmonchow/amq/services/pvsd.json
@@ -18,5 +18,10 @@
     {"frequency": 10,
       "message": {"src_name": "pvsd",
         "status": "0"}}
+  ],
+  "/topic/SNS.NOM.STATUS.PVSD": [
+    {"frequency": 10,
+      "message": {"src_name": "pvsd",
+        "status": "0"}}
   ]
 }

--- a/src/webmonchow/amq/services/translation.json
+++ b/src/webmonchow/amq/services/translation.json
@@ -59,6 +59,12 @@
         "ipts": "IPTS-33077",
         "run_number": "214747",
         "facility": "SNS",
-        "data_file": "/SNS/REF_L/IPTS-33077/nexus/REF_L_214747.nxs.h5"}}
+        "data_file": "/SNS/REF_L/IPTS-33077/nexus/REF_L_214747.nxs.h5"}},
+    {"frequency": 0,
+      "message": {"instrument": "NOM",
+        "ipts": "IPTS-1001",
+        "run_number": "10002",
+        "facility": "SNS",
+        "data_file": "/SNS/NOM/IPTS-1001/nexus/NOM_10002.nxs.h5"}}
   ]
 }


### PR DESCRIPTION
# Description of the changes

Add instrument NOM, since the latest autoreducer Docker image contains a reduction script for NOM for testing the new reduction job time limit.

Related changes to the autoreducer used in the test environment:
https://github.com/neutrons/data_workflow/pull/212

Check all that apply:
- [x] added [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) (if not, provide an explanation in the work description)
- [ ] ~~updated documentation~~
- [x] Source added/refactored
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Story 9317: [post-processing agent] Autoreduction job time limit](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9317)
- Links to related issues or pull requests:

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/webmonchow/blob/next/docs/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
